### PR TITLE
STEP5: 仮想環境でアプリを動かす

### DIFF
--- a/go/dockerfile
+++ b/go/dockerfile
@@ -2,9 +2,23 @@
 
 FROM golang:1.21.7-alpine
 
+WORKDIR /app
+
+RUN apk add --no-cache gcc musl-dev
+
+COPY db ./db
+COPY go/app ./go/app
+
+WORKDIR /app/go
+
+RUN go mod download
+RUN CGO_ENABLED=1 go build -o ./mercari-build-training ./app/*.go
+
 RUN addgroup -S mercari && adduser -S trainee -G mercari
 # RUN chown -R trainee:mercari /path/to/db
 
 USER trainee
 
-CMD ["go", "version"]
+EXPOSE 9000
+
+CMD [ "/app/go/mercari-build-training" ]

--- a/go/dockerfile
+++ b/go/dockerfile
@@ -1,4 +1,6 @@
-FROM alpine
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21.7-alpine
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari
 # RUN chown -R trainee:mercari /path/to/db

--- a/go/dockerfile
+++ b/go/dockerfile
@@ -8,6 +8,8 @@ RUN apk add --no-cache gcc musl-dev
 
 COPY db ./db
 COPY go/app ./go/app
+COPY go/go.mod ./go/
+COPY go/go.sum ./go/
 
 WORKDIR /app/go
 

--- a/go/dockerfile
+++ b/go/dockerfile
@@ -6,15 +6,13 @@ WORKDIR /app
 
 RUN apk add --no-cache gcc musl-dev
 
-COPY db ./db
-COPY go/app ./go/app
-COPY go/go.mod ./go/
-COPY go/go.sum ./go/
+COPY db/ ./db/
+COPY go/ ./go/
 
 WORKDIR /app/go
 
 RUN go mod tidy
-RUN CGO_ENABLED=1 go build -o ./mercari-build-training ./app/*.go
+RUN go build -o ./mercari-build-training ./app/*.go
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari
 # RUN chown -R trainee:mercari /path/to/db

--- a/go/dockerfile
+++ b/go/dockerfile
@@ -13,7 +13,7 @@ COPY go/go.sum ./go/
 
 WORKDIR /app/go
 
-RUN go mod download
+RUN go mod tidy
 RUN CGO_ENABLED=1 go build -o ./mercari-build-training ./app/*.go
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari


### PR DESCRIPTION
## What

### 1. Docker をインストールする

```shell
$ docker -v
Docker version 25.0.3, build 4debf41
```

### 2. Docker を触ってみる

- 家にあった処方箋を読ませてみた

```shell
$ docker run -v $(pwd)/data/IMG_6781.JPG:/tmp/img.jpg wakanapo/tesseract-ocr tesseract /tmp/img.jpg stdout -l jpn
Warning: Invalid resolution 0 dpi. Using 70 instead.
Estimating resolution as 572


_4.カロナール錠300 (自)

錠    まの作用            注意事項
| 熱を下げたり、痛みを | @      仙
間 | 寝前  やわらげるお業です.     時ばきけておのみ下さ  >
...
```

### 3. Docker Image を取得する

- images: ローカルのホスト上にあるイメージの一覧を表示
- help: dockerで使えるコマンドの一覧を表示
- pull: レジストリからimageを取得
  - [alpine - Official Image | Docker Hub](https://hub.docker.com/_/alpine)は、`docker pull alpine` でイメージを取得する。

### 4. Docker Image を Build する

```shell
$ docker build -t build2024/app:latest .
...
$ docker images
REPOSITORY               TAG       IMAGE ID       CREATED         SIZE
build2024/app            latest    703d7bfc941c   9 minutes ago   7.38MB
alpine                   latest    05455a08881e   3 weeks ago     7.38MB
hello-world              latest    d2c94e258dcb   9 months ago    13.3kB
wakanapo/tesseract-ocr   latest    b13469b4999f   21 months ago   167MB
```

### 5. Dockerfile を 変更する

Dockerfile変更前

```shell
$ docker run build2024/app:latest
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "go": executable file not found in $PATH: unknown.
```

Dockerfile変更後

```shell
$ docker run build2024/app:latest
go version go1.21.7 linux/amd64
$ go version
go version go1.21.7 linux/amd64
```

- 現在使用しているgoのバージョンと同一のバージョンが表示することができた
- dockerfileのbase imageを変更し、go1.21.7がインストールされているalpineイメージを使用した
  - `FROM golang:1.21.7-alpine`

### 6. 出品 API を docker 上で動かす

```shell
$ docker run -d -p 9000:9000 build2024/app:latest
e363a91b0831ff2ceb82ffedcf0bc924a9dbe07796f67611b12cce14d0138145
$ curl -X GET 'http://127.0.0.1:9000/items/1'
{"Id":1,"Name":"jacket","CategoryName":"fashion","ImageName":"bb4c9e59bf4408dcbeb3447aea026f3ba8613725bbbee8f3c67028a7e9ee11d7.jpg"}
```

- `WORKDIR /app`を大本のディレクトリに設定した
  - rootにgoディレクトリを作ると、`$GOHOME`と同じ値になるため怒られる
- PATH関連で詰まったが、 https://mercari.slack.com/archives/C06JXNMVCR0/p1708331090569179 を参考に実装できた
- CGO関連のエラーに悩まされた。結果的に、go-sqlite3するにはcgoが必要で、そのためのパッケージをインストールする処理を追加した
  - エラーは`"message":"Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub"`
  - dockerfileに`RUN apk add --no-cache gcc musl-dev`, `RUN CGO_ENABLED=1 go build...` を追加した
  - ただ、めちゃくちゃ時間がかかる。なんとかならないか
- 最初は`docker logs <container id>`でログが見られるのを知らず、パス関係のエラーだと思っていた
  - goディレクトリからの相対パスだと動かないのかと思ったが、そんなことはなかった

### Others / その他

- いちいちコンテナをpsしてidをコピーしてstopしないといけないのが面倒だったが、docker stop `docker ps -a -q`とすれば1行でできた

## Thinking / 感想

- Dockerをほとんど初めて触ったが、使うのは楽だがイメージを作るのが慣れなかった。volumeやdocker-composeなど、まだ実装できていない/出てきていない部分もあるので、色々いじってみたい。

## Upcoming improvements / 実装したい改善点

- 今回の課題は`$ docker run -d -p 9000:9000 build2024/app:latest`で動かすという指定があったので、`-v`オプションでVolumeを使うことができなかった。dockerfileでVOLUMEコマンドがあるが、`-v`オプションと挙動が違いそうなので、調査して使えたら使いたい

## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
